### PR TITLE
Closes #68 Reject: Close invalid GPU-BLAST report due to driver mismatch

### DIFF
--- a/__mods2/DoublyLinkedListTest.php
+++ b/__mods2/DoublyLinkedListTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../../DataStructures/DoublyLinkedList.php';
+
+/**
+ * Tests for the Doubly Linked Lists class
+ */
+
+class DoublyLinkedListTest extends TestCase
+{
+    /**
+     * Constructor test
+     */
+    public function testConstructor()
+    {
+        $list = new DoublyLinkedList();
+        $this->assertEquals(0, $list->length());
+    }
+
+    /**
+     * Test for the append method
+     */
+    public function testAppend()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $this->assertEquals(3, $list->length());
+    }
+
+    /**
+     * Test for the insert method
+     */
+    public function testInsert()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $list->insert(1, 4);
+        $this->assertEquals(4, $list->length());
+    }
+
+    /**
+     * Test for the delete method
+     */
+    public function testDelete()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $list->delete(1);
+        $this->assertEquals(2, $list->length());
+    }
+
+    /**
+     * Test for the deleteAt method
+     */
+    public function testDeleteAt()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $list->deleteAt(1);
+        $this->assertEquals(2, $list->length());
+    }
+
+    /**
+     * Test for printList method
+     */
+    public function testPrintList()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $this->expectOutputString("1\n2\n3\n");
+        $list->printList();
+    }
+
+    /**
+     * Test for the printListReverse method
+     */
+    public function testPrintListReverse()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $this->expectOutputString("3\n2\n1\n");
+        $list->printListReverse();
+    }
+
+    /**
+     * Test for the reverse method
+     */
+    public function testReverse()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $list->reverse();
+        $this->expectOutputString("3\n2\n1\n");
+        $list->printList();
+    }
+
+    /**
+     * Test for the length method
+     */
+    public function testLength()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $this->assertEquals(3, $list->length());
+    }
+    /**
+     * Test for the Search method
+     */
+    public function testSearch()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $searchItem = $list->search(2);
+        $this->assertEquals(2, $searchItem->data);
+    }
+
+    /**
+     * Test for the isEmpty method
+     */
+    public function testIsEmpty()
+    {
+        $list = new DoublyLinkedList();
+        $this->assertEquals(true, $list->isEmpty());
+    }
+
+    /**
+     * Test for __toString method
+     */
+    public function testToString()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $this->expectOutputString("1, 2, 3");
+        echo $list;
+    }
+
+    /**
+     * Test for the toArray method
+     */
+    public function testToArray()
+    {
+        $list = new DoublyLinkedList();
+        $list->append(1);
+        $list->append(2);
+        $list->append(3);
+        $this->assertEquals([1,2,3], $list->toArray());
+    }
+}

--- a/__mods2/SelectionSortTest.kt
+++ b/__mods2/SelectionSortTest.kt
@@ -1,0 +1,31 @@
+package sort
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class SelectionSortTest {
+
+    @Test
+    fun testSelectionSort1() {
+        val array = arrayOf(4, 3, 2, 8, 1)
+        selectionSort(array)
+
+        assertArrayEquals(array, arrayOf(1, 2, 3, 4, 8))
+    }
+
+    @Test
+    fun testSelectionSort2() {
+        val array = arrayOf(20, 5, 16, -1, 6)
+        selectionSort(array)
+
+        assertArrayEquals(array, arrayOf(-1, 5, 6, 16, 20))
+    }
+
+    @Test
+    fun testSelectionSort3() {
+        val array = arrayOf("A", "D", "E", "C", "B")
+        selectionSort(array)
+
+        assertArrayEquals(array, arrayOf("A", "B", "C", "D", "E"))
+    }
+}


### PR DESCRIPTION
68 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.